### PR TITLE
Fix image download within Grafana

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "@grafana/toolkit": "^9.0.0",
     "@grafana/ui": "^9.0.0",
     "@semantic-release/git": "^10.0.1",
+    "@types/file-saver": "^2.0.5",
     "@types/lodash": "^4.14.168",
     "@types/plotly.js-basic-dist-min": "^2.12.0",
     "@types/react-plotly.js": "^2.2.4",
     "edit-json-file": "^1.7.0",
     "emotion": "10.0.27",
+    "file-saver": "^2.0.5",
     "plotly.js-basic-dist-min": "^2.13.3",
     "react-plotly.js": "^2.5.1",
     "semantic-release": "^19.0.2"

--- a/src/PlotlyPanel.tsx
+++ b/src/PlotlyPanel.tsx
@@ -158,7 +158,7 @@ export const PlotlyPanel: React.FC<Props> = (props) => {
   };
 
   const handleImageDownload = (gd: PlotlyHTMLElement) =>
-    toImage(gd, { format: 'jpeg', width, height }).then((data) => saveAs(data, props.title));
+    toImage(gd, { format: 'png', width, height }).then((data) => saveAs(data, props.title));
 
   return (
     <div>

--- a/src/decs.d.ts
+++ b/src/decs.d.ts
@@ -1,0 +1,14 @@
+// Augment module with missing 'Icons' type
+declare module 'plotly.js-basic-dist-min' {
+  import * as Plotly from 'plotly.js';
+  export = Plotly;
+  // From: https://github.com/plotly/plotly.js/blob/master/src/fonts/ploticon.js
+  export const Icons: {
+    [name: string]: {
+      width: number;
+      height: number;
+      path: string;
+      transform: string;
+    };
+  };
+}

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { MenuGroup, MenuItem, MenuItemsGroup } from '@grafana/ui';
 import Plotly from 'plotly.js-basic-dist-min';
 import createPlotlyComponent from 'react-plotly.js/factory';
-import { DataFrame } from '@grafana/data';
+import { DataFrame, GrafanaTheme2 } from '@grafana/data';
 import _ from 'lodash';
 
 export const notEmpty = <TValue,>(value: TValue | null | undefined): value is TValue => {
@@ -25,3 +25,7 @@ export const renderMenuItems = (items: MenuItemsGroup[]) => {
 // Create Plot component with minimized bundle instead of default
 // https://github.com/plotly/react-plotly.js/#customizing-the-plotlyjs-bundle
 export const Plot = createPlotlyComponent(Plotly);
+
+export const useTraceColors = (theme: GrafanaTheme2) => {
+  return useMemo(() => theme.visualization.palette.map(theme.visualization.getColorByName), [theme]);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2819,7 +2819,7 @@
 
 "@types/d3@^3":
   version "3.5.47"
-  resolved "https://registry.npmjs.org/@types/d3/-/d3-3.5.47.tgz"
+  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-3.5.47.tgz#b81042fcb0195c583fc037bc857d161469a7d175"
   integrity sha512-VkWIQoZXLFdcBGe5pdBKJmTU3fmpXvo/KV6ixvTzOMl1yJ2hbTXpfvsziag0kcaerPDwas2T0vxojwQG3YwivQ==
 
 "@types/eslint-scope@^3.7.3":
@@ -2874,6 +2874,11 @@
     "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
+
+"@types/file-saver@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.5.tgz#9ee342a5d1314bb0928375424a2f162f97c310c7"
+  integrity sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==
 
 "@types/fs-extra@^9.0.13":
   version "9.0.13"
@@ -3027,14 +3032,14 @@
 
 "@types/plotly.js-basic-dist-min@^2.12.0":
   version "2.12.0"
-  resolved "https://registry.npmjs.org/@types/plotly.js-basic-dist-min/-/plotly.js-basic-dist-min-2.12.0.tgz"
+  resolved "https://registry.yarnpkg.com/@types/plotly.js-basic-dist-min/-/plotly.js-basic-dist-min-2.12.0.tgz#5b635be9ae5676698b034015e7257ce3627dd09d"
   integrity sha512-g5/C7VNQZngKD8EvJv5Nh4X1ifnSsrFKQxWcg/eAUKovMNWvdgk239Yu1gsecCkqtUkjDL4hyCZYqgtvI3Bi2Q==
   dependencies:
     "@types/plotly.js" "*"
 
 "@types/plotly.js@*":
   version "2.12.2"
-  resolved "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-2.12.2.tgz"
+  resolved "https://registry.yarnpkg.com/@types/plotly.js/-/plotly.js-2.12.2.tgz#9e4c61d3aaf33aee98fc5bdbeffd6cd85271f3f8"
   integrity sha512-cYJMFl01yZVuyrJcDD5LZzRK0wlizWe4lqoT4x87v2TXISZ7HVioWxEVt9n3OiqHDWqqAGMx8Erj7TJ3PeMTjw==
   dependencies:
     "@types/d3" "^3"
@@ -5811,6 +5816,11 @@ file-loader@^6.2.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 file-selector@^0.4.0:
   version "0.4.0"
@@ -9100,9 +9110,9 @@ pkg-up@^3.1.0:
     find-up "^3.0.0"
 
 plotly.js-basic-dist-min@^2.13.3:
-  version "2.13.3"
-  resolved "https://registry.npmjs.org/plotly.js-basic-dist-min/-/plotly.js-basic-dist-min-2.13.3.tgz"
-  integrity sha512-StuHoq05mPUoc8P3IN147LmR0jAfe+xLZsD2z8FeZ2uVfcVOLEQoRm+EGtNiiuViSBP4t/Jv0pcPUeLoVIvHNw==
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/plotly.js-basic-dist-min/-/plotly.js-basic-dist-min-2.14.0.tgz#5026b3292d9d4d80c5c846a34d019ba23008f6ce"
+  integrity sha512-W3PpxHLdRIKFPIkn9ymn+PYjakrGzlDP0hq9UauIOxIkydfyvOg+SGnjOQWkvg9vNmI+nDjUqV+8jTcRqSmyzw==
 
 pngjs@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Something about having Plotly inside of Grafana is causing issues trying to download an image of the graph:

![6f73a14d-e579-49cf-86f9-ce2cd6c96630](https://user-images.githubusercontent.com/9257800/186271999-a83969d9-8a99-461e-8c37-27d024abd323.gif)
I think the URL it generates is not matching the domain, or something along those lines.

I re-wrote the file download using the same library that Plotly uses and got it to work. I had to add a custom modebar button that looks exactly the same as the built-in one. Now when you click the download button, it will directly download it to the file system instead of redirecting the browser. It will also use the panel's title as the filename and match the width/height of the panel.
